### PR TITLE
ci: pin GitHub Actions to commit SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
             python-version: pypy-3.11
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tools in CI venv
@@ -78,13 +78,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - run: pip install build
       - run: python -m build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -97,11 +97,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tools in CI virtualenv
@@ -45,7 +45,7 @@ jobs:
         pdm run python -m coverage run -m runtests
         pdm run python -m coverage xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml


### PR DESCRIPTION
Supply-chain hardening, fan-out from the wlsqm pilot.

Pins every `uses:` to an immutable commit SHA (+ `# vX.Y.Z` comment) instead of a floating tag/branch. A floating ref can be silently repointed if an action repo or maintainer account is compromised (cf. `tj-actions/changed-files`, March 2025); a SHA cannot. SHAs target the latest release of each action — all reviewed this session (codecov v7.0.0 GPG-signed with maintainer-key continuity; cibuildwheel v4.0.0 PyPA/henryiii). Dependabot understands SHA-pinned actions and bumps both the SHA and the comment, so updates still flow as reviewable PRs.

Pure hardening — pinned commits are the current latest releases, so CI runs the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)