### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   codecov:
 


### PR DESCRIPTION
Least-privilege `GITHUB_TOKEN`: adds top-level `permissions: contents: read` to every workflow.

Jobs otherwise inherit the repo-default token scope (often read-write). A poisoned transitive dependency running during install/build/test on a push to the default branch would then hold a write-capable token (push commits, cut releases). Read-only by default denies that. Publish jobs keep their own job-level `id-token: write` (job-level overrides the top-level default), so PyPI trusted publishing is unaffected.

Defense-in-depth complement to the SHA-pinning: pinning stops untrusted code from *running*; this caps what it can *do*. Fork-PR tokens are already read-only by GitHub design — this closes the push-triggered path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)